### PR TITLE
Export more functions from `Stubs.Syscall.*`

### DIFF
--- a/stubs-common/src/Stubs/Syscall/AArch32/Linux.hs
+++ b/stubs-common/src/Stubs/Syscall/AArch32/Linux.hs
@@ -11,7 +11,9 @@
 -- See <https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#arm-32_bit_EABI>
 -- for the system call number mapping
 module Stubs.Syscall.AArch32.Linux (
-  aarch32LinuxSyscallABI
+    aarch32LinuxSyscallArgumentRegisters
+  , aarch32LinuxSyscallReturnRegisters
+  , aarch32LinuxSyscallABI
   ) where
 
 import qualified Data.Parameterized.Classes as PC

--- a/stubs-common/src/Stubs/Syscall/X86_64/Linux.hs
+++ b/stubs-common/src/Stubs/Syscall/X86_64/Linux.hs
@@ -6,7 +6,11 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Stubs.Syscall.X86_64.Linux ( x86_64LinuxSyscallABI ) where
+module Stubs.Syscall.X86_64.Linux (
+    x86_64LinuxSyscallArgumentRegisters
+  , x86_64LinuxSyscallReturnRegisters
+  , x86_64LinuxSyscallABI
+  ) where
 
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.NatRepr as PN


### PR DESCRIPTION
`Stubs.Syscall.{AArch32,X86_64}.Linux` wasn't exporting functionality to determine the argument and result registers for system calls, which proves inconvenient for downstream usage. This patch exports these functions, much in the same vein as #17.