### PR TITLE
`stubs-common`: Export functionality for obtain syscall numbers from registers

### DIFF
--- a/stubs-common/src/Stubs/Syscall/AArch32/Linux.hs
+++ b/stubs-common/src/Stubs/Syscall/AArch32/Linux.hs
@@ -12,6 +12,7 @@
 -- for the system call number mapping
 module Stubs.Syscall.AArch32.Linux (
     aarch32LinuxSyscallArgumentRegisters
+  , aarch32LinuxSyscallNumberRegister
   , aarch32LinuxSyscallReturnRegisters
   , aarch32LinuxSyscallABI
   ) where

--- a/stubs-common/src/Stubs/Syscall/X86_64/Linux.hs
+++ b/stubs-common/src/Stubs/Syscall/X86_64/Linux.hs
@@ -8,6 +8,7 @@
 
 module Stubs.Syscall.X86_64.Linux (
     x86_64LinuxSyscallArgumentRegisters
+  , x86_64LinuxSyscallNumberRegister
   , x86_64LinuxSyscallReturnRegisters
   , x86_64LinuxSyscallABI
   ) where


### PR DESCRIPTION
A follow-up to #22.