### PR TITLE
Allow `generate_table.py` to exclude arbitrary ABIs

### DIFF
--- a/stubs-common/src/Stubs/Syscall/Names/AArch32/Linux.hs
+++ b/stubs-common/src/Stubs/Syscall/Names/AArch32/Linux.hs
@@ -5,7 +5,7 @@
 -- module does not carry any type information
 -- about the signatures of syscalls, only
 -- the information that's contained within
--- syscalls.tbl
+-- syscalls_arm.tbl.
 module Stubs.Syscall.Names.AArch32.Linux
     (
      syscallMap
@@ -22,7 +22,8 @@ syscallMap = IM.fromList armSyscalls_
 
 -- | The raw table of arm syscalls and their associated numbers.
 -- See syscall_arm.tbl for more information. This data is
--- generated automatically from the generate_table.py script.
+-- generated automatically from the generate_table.py script. See the
+-- @stubs-common/src/Stubs/Syscall/Names/README@ file for more information.
 armSyscalls_ :: [(Int, DT.Text)]
 armSyscalls_ = [
     (0, "restart_syscall"),

--- a/stubs-common/src/Stubs/Syscall/Names/README
+++ b/stubs-common/src/Stubs/Syscall/Names/README
@@ -3,6 +3,8 @@ Automatically generated int -> syscall conversions for different platforms
 syscall_arm.tbl and syscall_x86_64.tbl are tables of syscall codes on arm and x86 respectively.
 Their sources are given at the top of each file.
 
-To generate the data used in AArch32/Linux.hs and X86_64/Linux.hs, run `./generate_table.py syscall_arm.tbl` and `./generate_table.py syscall_x86_64.tbl` respectively, and paste the output into the list literal.
+To generate the data used in AArch32/Linux.hs and X86_64/Linux.hs, run one of
+the following commands and paste the output into the list literal:
 
-Note that for x86_64, syscalls with calling convention x32 are filtered out, and this is hardcoded into `generate_table.py`.
+* For AArch32: `./generate_table.py syscall_arm.tbl`
+* For x86_64:  `./generate_table.py syscall_x86_64.tbl --exclude-abi x32`

--- a/stubs-common/src/Stubs/Syscall/Names/X86_64/Linux.hs
+++ b/stubs-common/src/Stubs/Syscall/Names/X86_64/Linux.hs
@@ -5,7 +5,7 @@
 -- module does not carry any type information
 -- about the signatures of syscalls, only
 -- the information that's contained within
--- syscalls.tbl
+-- syscalls_x86_64.tbl.
 module Stubs.Syscall.Names.X86_64.Linux
     (
      syscallMap
@@ -22,7 +22,8 @@ syscallMap = IM.fromList x86_64Syscalls_
 
 -- | The raw table of x86 64-bit syscalls and their associated numbers.
 -- See syscall_x86_64.tbl for more information. This data is
--- generated automatically from the generate_table.py script.
+-- generated automatically from the generate_table.py script. See the
+-- @stubs-common/src/Stubs/Syscall/Names/README@ file for more information.
 x86_64Syscalls_ :: [(Int, DT.Text)]
 x86_64Syscalls_ = [
     (0, "read"),

--- a/stubs-common/src/Stubs/Syscall/Names/generate_table.py
+++ b/stubs-common/src/Stubs/Syscall/Names/generate_table.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
-import sys
+import argparse
 
-if len(sys.argv) == 1 or sys.argv[1] == "--help" or sys.argv[1] == "-h":
-    print("Usage: generate_table.py <input .tbl file>")
-    exit(1)
+parser = argparse.ArgumentParser(
+                    prog="generate_table.py",
+                    description="Generate a map of syscall names from a .tbl file")
+parser.add_argument("filename",
+                    help="The input .tbl file")
+parser.add_argument("--exclude-abi",
+                    help="Exclude syscalls that require the supplied ABI name",
+                    default=[],
+                    action="append")
 
-inpfile = sys.argv[1]
+args = parser.parse_args()
 
-with open(inpfile, "r") as f:
+with open(args.filename, "r") as f:
     data = f.readlines()
 
 failed = []
@@ -19,9 +25,9 @@ for line in data:
     try:
         parts = dat.split("\t")
         code = int(parts[0].strip())
-        # Special case: filter out syscalls that use the x32 abi
+        # Filter out syscalls that are in the list of excluded ABIs
         abi = parts[1].strip()
-        if abi == "x32":
+        if abi in args.exclude_abi:
             continue
         syscall = parts[2].strip()
         print(f"    ({code}, \"{syscall}\"),")


### PR DESCRIPTION
This generalizes the `generate_table.py` script to be able to exclude an arbitrary, user-supplied ABI name, rather than hard-coding the ABI name (e.g., `x32`) into the implementation of the script itself. This paves the way to be able to add syscall mappings for PowerPC.

Fixes https://github.com/GaloisInc/stubs/issues/34.