### PR TITLE
CI: Use `upload-artifact@v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         tar -cvf doc.tar.gz docs/book/*
 
     - name: Upload docs artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: github.repository == 'GaloisInc/${{ env.NAME }}'
       with:
         name: "${{ env.NAME }}-docs"


### PR DESCRIPTION
Support for @v3 will be dropped soon: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/