### PR TITLE
Cite `ambient-verifier` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@ cd doc/
 mdbook build
 ```
 
+Much of the code in this repository was originally developed as part of the
+[`ambient-verifier`](https://github.com/GaloisInc/ambient-verifier) tool.
+
 [macaw-symbolic]: https://github.com/GaloisInc/macaw/tree/master/symbolic


### PR DESCRIPTION
While we continue to refine and polish the code in `stubs`, it would be helpful to note that much of the code in the repo was originally taken from `ambient-verifier`, as there are still lingering references to it in the code and comments (see also #9).