### PR TITLE
Remove unused `.cabal` dependencies

### DIFF
--- a/stubs-common/src/Stubs/Extensions.hs
+++ b/stubs-common/src/Stubs/Extensions.hs
@@ -57,7 +57,6 @@ import qualified Data.Macaw.Symbolic as DMS
 import qualified Data.Macaw.Symbolic.Memory.Lazy as DMSM
 import qualified Data.Macaw.Symbolic.Backend as DMSB
 import qualified Data.Macaw.Symbolic.MemOps as DMSMO
-import Data.Macaw.Symbolic.MemOps ()
 import qualified Lang.Crucible.Backend as LCB
 import qualified Lang.Crucible.Backend.Online as LCBO
 import qualified Lang.Crucible.LLVM.MemModel as LCLM

--- a/stubs-common/src/Stubs/Memory/X86_64/Linux.hs
+++ b/stubs-common/src/Stubs/Memory/X86_64/Linux.hs
@@ -63,7 +63,6 @@ import qualified Stubs.Extensions as SE
 import qualified Data.Macaw.Symbolic as DMSMO
 import qualified Stubs.Loader.BinaryConfig as SLB
 import qualified Data.Macaw.BinaryLoader as DMB
-import Data.Macaw.BinaryLoader.X86 ()
 
 instance SM.IsStubsMemoryModel DMS.LLVMMemory DMX.X86_64 where
   type instance PtrType DMS.LLVMMemory DMX.X86_64 =  LCLM.LLVMPointerType (DMC.ArchAddrWidth DMX.X86_64)

--- a/stubs-common/src/Stubs/Syscall.hs
+++ b/stubs-common/src/Stubs/Syscall.hs
@@ -19,7 +19,6 @@ import qualified Data.Kind as Kind
 import qualified Data.Parameterized.Classes as PC
 import qualified Data.Parameterized.Context as Ctx
 
-import           Data.Macaw.X86.Symbolic ()
 import qualified Lang.Crucible.Backend as LCB
 import qualified Lang.Crucible.Backend.Online as LCBO
 import qualified Lang.Crucible.FunctionHandle as LCF

--- a/stubs-common/stubs-common.cabal
+++ b/stubs-common/stubs-common.cabal
@@ -97,7 +97,6 @@ library
                       macaw-base,
                       macaw-symbolic,
                       macaw-loader,
-                      macaw-loader-x86,
                       semmc-aarch32,
                       macaw-x86,
                       macaw-x86-symbolic,

--- a/stubs-common/stubs-common.cabal
+++ b/stubs-common/stubs-common.cabal
@@ -24,14 +24,12 @@ extra-source-files: CHANGELOG.md
 
 common shared
     build-depends:
-        async >= 2 && < 3,
         base >= 4.10 && < 5,
         bytestring,
         bv-sized,
         containers,
         exceptions,
         filepath,
-        Glob,
         lens >= 4 && < 6,
         lumberjack >= 1 && < 1.1,
         megaparsec >= 7 && < 10,
@@ -41,7 +39,6 @@ common shared
         parser-combinators >= 1.2 && < 1.4,
         prettyprinter >= 1.7 && < 1.8,
         prettyprinter-ansi-terminal,
-        yaml >= 0.11 && < 0.12,
         text
 
 library
@@ -101,14 +98,9 @@ library
                       macaw-symbolic,
                       macaw-loader,
                       macaw-loader-x86,
-                      macaw-loader-aarch32,
                       semmc-aarch32,
-                      directory,
-                      file-embed,
-                      flexdis86,
                       macaw-x86,
                       macaw-x86-symbolic,
-                      asl-translator,
                       macaw-aarch32,
                       macaw-aarch32-symbolic,
                       dismantle-ppc,
@@ -117,19 +109,12 @@ library
                       macaw-ppc-symbolic,
                       crucible,
                       crucible-llvm,
-                      crucible-symio,
                       crucible-syntax,
                       what4,
                       binary-symbols,
                       language-c,
-                      indexed-traversable,
-                      utf8-string,
                       nonempty-vector,
                       vector,
-                      multiset,
-                      IntervalMap,
-                      split,
-                      temporary,
                       aeson >= 2
 
     hs-source-dirs:   src

--- a/stubs-loader/stubs-loader.cabal
+++ b/stubs-loader/stubs-loader.cabal
@@ -24,25 +24,13 @@ extra-source-files: CHANGELOG.md
 
 common shared
     build-depends:
-        async >= 2 && < 3,
         base >= 4.10 && < 5,
         bytestring,
-        bv-sized,
         containers,
         exceptions,
         filepath,
-        Glob,
-        lens >= 4 && < 6,
-        lumberjack >= 1 && < 1.1,
-        megaparsec >= 7 && < 10,
-        mtl >= 2 && < 3,
-        panic >= 0.4 && < 0.5,
         pe-parser,
         parameterized-utils >= 2 && < 3,
-        parser-combinators >= 1.2 && < 1.4,
-        prettyprinter >= 1.7 && < 1.8,
-        prettyprinter-ansi-terminal,
-        yaml >= 0.11 && < 0.12,
         text
 
 library
@@ -61,7 +49,6 @@ library
                    directory,
                    vector,
                    binary-symbols,
-                   asl-translator,
                    dismantle-ppc,
                    what4,
                    crucible,
@@ -79,5 +66,4 @@ library
                    macaw-aarch32-symbolic,
                    macaw-loader-aarch32,
                    macaw-ppc,
-                   macaw-ppc-symbolic,
-                   macaw-loader-ppc
+                   macaw-ppc-symbolic

--- a/stubs-parser/stubs-parser.cabal
+++ b/stubs-parser/stubs-parser.cabal
@@ -24,20 +24,11 @@ extra-source-files: CHANGELOG.md
 
 common shared
     build-depends:
-        async >= 2 && < 3,
         base >= 4.10 && < 5,
-        bytestring,
-        containers,
-        exceptions,
-        filepath,
-        Glob,
-        mtl >= 2 && < 3,
-        panic >= 0.4 && < 0.5,
-        parameterized-utils >= 2 && < 3,
-        text
+        mtl >= 2 && < 3
 
-library 
-    import: shared 
+library
+    import: shared
     exposed-modules: Stubs.Parser,
                      Stubs.Lexer,
                      Stubs.Token,
@@ -46,15 +37,14 @@ library
                      Stubs.Lower,
                      Stubs.Parser.Exception
     hs-source-dirs: src
-    default-language: Haskell2010 
+    default-language: Haskell2010
     ghc-options: -Wextra -Wcompat
-    build-depends: directory,
-                   vector,
-                   array,
-                   utf8-string,
-                   stubs-common,
+    build-depends: array,
+                   containers,
+                   filepath,
+                   parameterized-utils >= 2 && < 3,
                    stubs-translator,
-                   what4
+                   text
     build-tools: alex, happy
 
 test-suite parser-tests
@@ -62,11 +52,9 @@ test-suite parser-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: tests
-  default-language: Haskell2010 
+  default-language: Haskell2010
   ghc-options: -Wextra -Wcompat
-  build-depends: stubs-common,
-                 stubs-parser,
+  build-depends: stubs-parser,
                  stubs-translator,
                  tasty,
-                 tasty-expected-failure,
                  tasty-hunit

--- a/stubs-translator/stubs-translator.cabal
+++ b/stubs-translator/stubs-translator.cabal
@@ -25,21 +25,8 @@ extra-source-files: CHANGELOG.md
 
 common shared
     build-depends:
-        async >= 2 && < 3,
         base >= 4.10 && < 5,
-        bytestring,
-        bv-sized,
-        containers,
-        exceptions,
-        filepath,
-        Glob,
-        lens >= 4 && < 6,
-        mtl >= 2 && < 3,
-        panic >= 0.4 && < 0.5,
-        parameterized-utils >= 2 && < 3,
-        prettyprinter >= 1.7 && < 1.8,
-        prettyprinter-ansi-terminal,
-        text
+        parameterized-utils >= 2 && < 3
 
 library
     import: shared
@@ -57,22 +44,21 @@ library
     hs-source-dirs: src
     default-language: Haskell2010
     ghc-options: -Wextra -Wcompat
-    build-depends: stubs-common,
+    build-depends: containers,
+                   exceptions,
+                   mtl >= 2 && < 3,
+                   text,
+
+                   stubs-common,
                    what4,
                    crucible,
                    crucible-syntax,
                    macaw-base,
-                   binary-symbols,
-                   macaw-loader,
-                   nonempty-vector,
                    parameterized-utils,
                    crucible-llvm,
-                   split,
                    macaw-symbolic,
-                   IntervalMap,
                    macaw-x86-symbolic,
                    macaw-x86,
-                   macaw-aarch32,
                    macaw-aarch32-symbolic,
                    semmc-aarch32,
                    macaw-ppc,
@@ -83,20 +69,11 @@ test-suite translator-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: tests
-  build-depends: stubs-common,
-                 stubs-translator,
+  build-depends: stubs-translator,
                  crucible,
-                 crucible-syntax,
                  macaw-base,
-                 macaw-symbolic,
-                 crucible-llvm,
-                 what4,
-                 directory,
                  tasty,
-                 tasty-ant-xml,
-                 tasty-expected-failure,
                  tasty-hunit,
-                 yaml >= 0.11 && < 0.12,
                  macaw-x86,
                  macaw-x86-symbolic
   ghc-options: -Wextra -Wcompat

--- a/stubs-wrapper/stubs-wrapper.cabal
+++ b/stubs-wrapper/stubs-wrapper.cabal
@@ -24,26 +24,12 @@ extra-source-files: CHANGELOG.md
 
 common shared
     build-depends:
-        async >= 2 && < 3,
         base >= 4.10 && < 5,
-        bytestring,
-        bv-sized,
         containers,
         exceptions,
         filepath,
-        Glob,
-        lens >= 4 && < 6,
-        lumberjack >= 1 && < 1.1,
-        megaparsec >= 7 && < 10,
-        mtl >= 2 && < 3,
-        panic >= 0.4 && < 0.5,
         parameterized-utils >= 2 && < 3,
-        parser-combinators >= 1.2 && < 1.4,
-        prettyprinter >= 1.7 && < 1.8,
-        prettyprinter-ansi-terminal,
-        yaml >= 0.11 && < 0.12,
-        text,
-        template-haskell
+        text
 
 library
     import: shared
@@ -58,16 +44,5 @@ library
                    crucible,
                    crucible-syntax,
                    macaw-base,
-                   binary-symbols,
-                   macaw-loader,
-                   nonempty-vector,
                    parameterized-utils,
-                   crucible-llvm,
-                   split,
-                   macaw-symbolic,
-                   IntervalMap,
-                   macaw-x86-symbolic,
-                   macaw-x86,
-                   macaw-aarch32,
-                   macaw-aarch32-symbolic,
-                   semmc-aarch32
+                   macaw-symbolic

--- a/stubs.cabal
+++ b/stubs.cabal
@@ -27,25 +27,7 @@ extra-source-files: CHANGELOG.md
 
 common shared
     build-depends:
-        async >= 2 && < 3,
-        base >= 4.10 && < 5,
-        bytestring,
-        bv-sized,
-        containers,
-        exceptions,
-        filepath,
-        Glob,
-        lens >= 4 && < 6,
-        lumberjack >= 1 && < 1.1,
-        megaparsec >= 7 && < 10,
-        mtl >= 2 && < 3,
-        panic >= 0.4 && < 0.5,
-        parameterized-utils >= 2 && < 3,
-        parser-combinators >= 1.2 && < 1.4,
-        prettyprinter >= 1.7 && < 1.8,
-        prettyprinter-ansi-terminal,
-        yaml >= 0.11 && < 0.12,
-        text
+        base >= 4.10 && < 5
 
 library
     build-depends: stubs-common,
@@ -68,10 +50,7 @@ executable stubs
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
-    build-depends:
-        gitrev,
-        optparse-applicative,
-        stubs
+    -- build-depends:
 
     hs-source-dirs:   tools/stubs
     default-language: Haskell2010
@@ -94,10 +73,6 @@ test-suite stubs-tests
                  stubs-parser,
                  stubs-loader,
                  stubs-translator,
-                 binary-symbols,
-                 vector,
-                 nonempty-vector,
-                 crucible-symio,
                  crucible,
                  macaw-base,
                  macaw-symbolic,
@@ -105,14 +80,20 @@ test-suite stubs-tests
                  macaw-loader,
                  macaw-loader-x86,
                  macaw-x86-symbolic,
-                 crucible-syntax,
                  crucible-llvm,
                  what4,
-                 directory,
+                 parameterized-utils >= 2 && < 3,
+
+                 bytestring,
+                 bv-sized,
+                 containers,
+                 exceptions,
+                 lens >= 4 && < 6,
+                 lumberjack >= 1 && < 1.1,
+                 mtl >= 2 && < 3,
                  tasty,
-                 tasty-ant-xml,
-                 tasty-expected-failure,
                  tasty-hunit,
-                 yaml >= 0.11 && < 0.12
+                 text,
+                 vector
   ghc-options: -Wextra -Wcompat
   default-language: Haskell2010

--- a/tests/Infrastructure.hs
+++ b/tests/Infrastructure.hs
@@ -30,8 +30,6 @@ import qualified Stubs.Memory as AM
 import qualified Stubs.Solver as AS
 import qualified Data.Macaw.Symbolic as DMS
 
-import           Data.Macaw.BinaryLoader.X86 ()
-import           Data.Macaw.X86.Symbolic ()
 import qualified Lang.Crucible.FunctionHandle as LCF
 
 import qualified What4.Interface as WI

--- a/tests/Stubs/SymbolicExecution.hs
+++ b/tests/Stubs/SymbolicExecution.hs
@@ -87,8 +87,6 @@ import qualified Stubs.Translate.Core as STC
 import qualified Stubs.Preamble as SPR
 import qualified Stubs.Common as SC
 import qualified Stubs.Memory as SM
-import qualified Stubs.Memory.X86_64.Linux ()
-import qualified Stubs.Memory.AArch32.Linux ()
 import qualified Lang.Crucible.LLVM.Errors as LCLE
 import qualified Lang.Crucible.LLVM.MemModel.Partial as LCLMP
 import qualified Lang.Crucible.LLVM.MemModel.CallStack as LCLMC
@@ -502,7 +500,7 @@ simulateFunction logAction bak execFeatures halloc archInfo archVals seConf init
   initCOvs <- liftIO $ mapM (SW.genInitOvHooks tsym) crProgs
   let SM.BuildSyscallABI buildSyscallABI = abiBuildSyscallABI fnConf
   let syscallABI = buildSyscallABI initialMem (ALB.bcUnsuportedRelocations binConf)
-  let SM.BuildFunctionABI buildFunctionABI = abiBuildFunctionABI fnConf 
+  let SM.BuildFunctionABI buildFunctionABI = abiBuildFunctionABI fnConf
   let functionABI = buildFunctionABI AF.TestContext initialMem archVals
                                      (ALB.bcUnsuportedRelocations binConf)
                                      mempty


### PR DESCRIPTION
`-Wunused-packages` warns about several dependencies in the `.cabal` files being unused, so let's remove them.