### PR TITLE
Drop unnecessary `allow-newers` from `cabal.project.dist`

### DIFF
--- a/cabal.project.dist
+++ b/cabal.project.dist
@@ -1,10 +1,3 @@
--- TODO: https://github.com/travitch/itanium-abi/pull/15
-allow-newer: itanium-abi:text
--- See https://github.com/Happstack/boomerang/issues/12
-allow-newer: boomerang:template-haskell
--- See https://github.com/travitch/haggle/issues/29
-allow-newer: haggle:primitive
-
 packages: .
           ./stubs-parser
           ./stubs-common


### PR DESCRIPTION
The upstream issues have all been fixed.